### PR TITLE
Fixed model_save_dir naming bug in main

### DIFF
--- a/main.py
+++ b/main.py
@@ -32,7 +32,7 @@ def setup_directories(config_path: str = "config.yaml"):
     directories = [
         os.path.dirname(config['training']['log_file']),
         config['data']['embeddings_cache_dir'],
-        os.path.dirname(config['training']['model_save_path']),
+        os.path.dirname(config['training']['model_save_dir']),
     ]
     
     for directory in directories:


### PR DESCRIPTION
"model_save_dir" was named "model_save_path" in `main.py`. Have changed main.py to match "model_save_dir".