### PR TITLE
Feat/hf dataloader

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -4,22 +4,45 @@ This guide explains how to use the antibody classification pipeline with ESM-1V 
 
 ## Quick Start
 
+# Configure Dataset source
+## Option 1: local dataset
 1. **Prepare your data**:
-   Create a CSV file with your antibody sequences and binary labels:
-   ```csv
-   sequence,label
-   QVQLVQSGAEVKKPGASVKVSCKASGYTFTSYYMHWVRQAPGQGLEWMGWINPNSGGTNYAQKFQGRVTMTRDTSISTAYMELSRLRSDDTAVYYCARSTYYGGDWYFNVWGQGTLVTVSS,1
-   EVQLLESGGGLVQPGGSLRLSCAASGFTFSSYAMSWVRQAPGKGLEWVSAISGSGGSTYYADSVKGRFTISRDNSKNTLYLQMNSLRAEDTAVYYCARQHYDWPWGQGTLVTVSS,0
-   ```
+
+  Create a CSV file with your antibody sequences and binary labels:
+  ```csv
+  sequence,label
+  QVQLVQSGAEVKKPGASVKVSCKASGYTFTSYYMHWVRQAPGQGLEWMGWINPNSGGTNYAQKFQGRVTMTRDTSISTAYMELSRLRSDDTAVYYCARSTYYGGDWYFNVWGQGTLVTVSS,1
+  EVQLLESGGGLVQPGGSLRLSCAASGFTFSSYAMSWVRQAPGKGLEWVSAISGSGGSTYYADSVKGRFTISRDNSKNTLYLQMNSLRAEDTAVYYCARQHYDWPWGQGTLVTVSS,0
+  ```
 
 2. **Update configuration**:
-   Edit `config.yaml` to point to your data file:
-   ```yaml
-   data:
-     train_file: "path/to/your/training_data.csv"
-   ```
+  Edit `config.yaml` to point to your data file:
+  ```yaml
+  data:
+    train_file: "path/to/your/training_data.csv"
+  ```
+3. **update source**
+  Edit load_data in `train.py` 
+  ```python
+  load_data(config, source='local')
+  ```
 
-3. **Run training**:
+## Option 2: HuggingFace dataset
+
+1. **Update configuration**:
+  Edit `config.yaml` with dataset name:
+  ```yaml
+  data:
+    dataset_name: "VH_dataset"
+  ```
+
+2. **update source**
+  Edit load_data in `train.py` 
+  ```python
+  load_data(config, source='hf')
+  ```
+
+# Run training pipeline
    ```bash
    python main.py
    ```

--- a/USAGE.md
+++ b/USAGE.md
@@ -22,9 +22,10 @@ This guide explains how to use the antibody classification pipeline with ESM-1V 
     train_file: "path/to/your/training_data.csv"
   ```
 3. **update source**
-  Edit load_data in `train.py` 
-  ```python
-  load_data(config, source='local')
+  Edit `config.yaml` with the desired source:
+  ```yaml
+  data:
+    source: "local"
   ```
 
 ## Option 2: HuggingFace dataset
@@ -37,9 +38,10 @@ This guide explains how to use the antibody classification pipeline with ESM-1V 
   ```
 
 2. **update source**
-  Edit load_data in `train.py` 
-  ```python
-  load_data(config, source='hf')
+  Edit `config.yaml` with the desired source:
+  ```yaml
+  data:
+    source: "hf"
   ```
 
 # Run training pipeline

--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,7 @@ model:
 
 # Data configuration
 data:
+  dataset_name: "VH_dataset"
   train_file: ./train_datasets/VH_only_training_ready.csv  # Path to training data (sequences and labels)
   val_file: null    # Path to validation data (optional)
   test_file: null   # Path to test data (optional)

--- a/config.yaml
+++ b/config.yaml
@@ -7,6 +7,7 @@ model:
 
 # Data configuration
 data:
+  source: "local" # Data source type: local, HF
   dataset_name: "VH_dataset"
   train_file: ./train_datasets/VH_only_training_ready.csv  # Path to training data (sequences and labels)
   val_file: null    # Path to validation data (optional)

--- a/data.py
+++ b/data.py
@@ -3,6 +3,8 @@ import pickle
 import numpy as np
 from typing import List, Tuple, Dict, Optional, Any
 from sklearn.preprocessing import StandardScaler
+from datasets import load_dataset
+
 
 logger = logging.getLogger(__name__)
 
@@ -67,3 +69,28 @@ def load_preprocessed_data(filename: str) -> Dict:
     """
     with open(filename, 'rb') as f:
         return pickle.load(f)
+    
+def load_hf_dataset(
+    dataset_name: str,
+    split: str,
+    text_column: str,
+    label_column: str,
+) -> Tuple[List[str], List[Any]]:
+    """
+    Load a dataset from Hugging Face datasets library.
+
+    Args:
+        dataset_name: Name of the dataset to load
+        split: Which split to load (e.g., 'train', 'test', 'validation')
+        text_column: Name of the column containing the sequences
+        label_column: Name of the column containing the labels
+
+    Returns:
+        X: List of input sequences (strings)
+        y: List or array of labels
+    """
+    dataset = load_dataset(dataset_name, split=split)
+    X = dataset[text_column]
+    y = dataset[label_column]
+
+    return list(X), list(y)

--- a/data.py
+++ b/data.py
@@ -119,26 +119,25 @@ def load_local_data(
 
     return X_train, y_train
 
-def load_data(config: Dict, *, source: Literal['hf', 'local']) -> Tuple[List[str], List[int]]:
+def load_data(config: Dict) -> Tuple[List[str], List[int]]:
     """
     Load training data from either Hugging Face datasets or local file based on source parameter
     
     args:
         config: Configuration dictionary containing data parameters
-        source: 'hf' to load from Hugging Face datasets, 'local' to load from local file
 
     Returns:
         X_train, y_train
     """
     data_config = config['data']
-    if source == 'hf':
+    if data_config['source'] == "hf":
         return load_hf_dataset(
             dataset_name=data_config['dataset_name'],
             split=data_config['train_split'],
             text_column=data_config['sequence_column'],
             label_column=data_config['label_column']
         )
-    elif source == 'local':
+    elif data_config['source'] == "local":
         return load_local_data(
             data_config['file_path'],
             text_column=data_config['sequence_column'],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pyparsing>=3.0.0",
     'plotly',
     "jupyterlab>=4.4.9",
+    "datasets>=4.2.0",
 ]
 
 [project.optional-dependencies]

--- a/train.py
+++ b/train.py
@@ -19,7 +19,7 @@ from sklearn.metrics import (
 
 from model import ESMEmbeddingExtractor
 from classifier import BinaryClassifier
-from data import preprocess_raw_data, store_preprocessed_data, load_preprocessed_data, load_hf_dataset
+from data import load_data
 import shutil
 
 def setup_logging(config: Dict) -> logging.Logger:
@@ -235,11 +235,8 @@ def train_model(config_path: str = "config.yaml") -> Dict[str, Any]:
     
     try:
         # Load data
-        X_train, y_train = load_hf_dataset(config['dataset'],
-                                           config['data']['train_split'],
-                                           config['data']['sequence_column'],
-                                           config['data']['label_column']
-                                           )
+        X_train, y_train = load_data(config, source="local")
+
         logger.info(f"Loaded {len(X_train)} training samples")
 
         # Initialize embedding extractor and classifier

--- a/train.py
+++ b/train.py
@@ -235,7 +235,7 @@ def train_model(config_path: str = "config.yaml") -> Dict[str, Any]:
     
     try:
         # Load data
-        X_train, y_train = load_data(config, source="local")
+        X_train, y_train = load_data(config)
 
         logger.info(f"Loaded {len(X_train)} training samples")
 

--- a/train.py
+++ b/train.py
@@ -19,7 +19,7 @@ from sklearn.metrics import (
 
 from model import ESMEmbeddingExtractor
 from classifier import BinaryClassifier
-from data import preprocess_raw_data, store_preprocessed_data, load_preprocessed_data
+from data import preprocess_raw_data, store_preprocessed_data, load_preprocessed_data, load_hf_dataset
 import shutil
 
 def setup_logging(config: Dict) -> logging.Logger:
@@ -47,29 +47,6 @@ def load_config(config_path: str) -> Dict:
     with open(config_path, 'r') as f:
         config = yaml.safe_load(f)
     return config
-
-def load_data(config: Dict, logger: logging.Logger) -> Tuple[List[str], List[int]]:
-    """
-    Load training data from file
-    
-    Returns:
-        X_train, y_train
-    """
-    data_config = config['data']
-    
-    if data_config['train_file'] is None:
-        raise ValueError("train_file must be specified in config")
-    
-    # Load training data
-    logger.info(f"Loading training data from {data_config['train_file']}")
-    train_df = pd.read_csv(data_config['train_file'])
-    
-    X_train = train_df[data_config['sequence_column']].tolist()
-    y_train = train_df[data_config['label_column']].tolist()
-    
-    logger.info(f"Loaded {len(X_train)} training samples")
-    
-    return X_train, y_train
 
 
 def get_or_create_embeddings(
@@ -258,8 +235,13 @@ def train_model(config_path: str = "config.yaml") -> Dict[str, Any]:
     
     try:
         # Load data
-        X_train, y_train = load_data(config, logger)
-        
+        X_train, y_train = load_hf_dataset(config['dataset'],
+                                           config['data']['train_split'],
+                                           config['data']['sequence_column'],
+                                           config['data']['label_column']
+                                           )
+        logger.info(f"Loaded {len(X_train)} training samples")
+
         # Initialize embedding extractor and classifier
         logger.info("Initializing ESM embedding extractor and classifier")
         classifier_params = config['classifier'].copy()


### PR DESCRIPTION
This PR updates the dataset loading functionality in the pipeline by replacing pd.read_csv with a Hugging Face datasets loader.

Changes:

- Added load_hf_dataset() function to load datasets directly from the Hugging Face Hub.
- Function converts datasets.arrow_dataset.Column objects to Python lists for compatibility with scikit-learn pipelines.
- Replaces previous CSV-based dataset loading (pd.read_csv) in train.py.
- Supports specifying:
> - Dataset name (dataset_name)
> - Split (train, test, validation)
> - Text column (text_column)
> - Label column (label_column)

Resolves #5 